### PR TITLE
Set default size to vector graphic

### DIFF
--- a/templates/images/icon_xlvo.svg
+++ b/templates/images/icon_xlvo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 595.3 841.9" enable-background="new 0 0 595.3 841.9" xml:space="preserve">
+	 width="8mm" height="8mm" viewBox="0 0 595.3 841.9" enable-background="new 0 0 595.3 841.9" xml:space="preserve">
 <g id="Ebene_2_1_">
 	<circle fill="#52658A" cx="283.3" cy="434.4" r="348.9"/>
 </g>

--- a/templates/images/icon_xlvo.svg
+++ b/templates/images/icon_xlvo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="32px" height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+	 width="32px" height="32px" viewBox="0 0 595.3 841.9" enable-background="new 0 0 595.3 841.9" xml:space="preserve">
 <g id="Ebene_2_1_">
 	<circle fill="#52658A" cx="283.3" cy="434.4" r="348.9"/>
 </g>

--- a/templates/images/icon_xlvo.svg
+++ b/templates/images/icon_xlvo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="32px" height="32px" viewBox="0 0 595.3 841.9" enable-background="new 0 0 595.3 841.9" xml:space="preserve">
+	 width="32px" height="32px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
 <g id="Ebene_2_1_">
 	<circle fill="#52658A" cx="283.3" cy="434.4" r="348.9"/>
 </g>

--- a/templates/images/icon_xlvo.svg
+++ b/templates/images/icon_xlvo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="8mm" height="8mm" viewBox="0 0 595.3 841.9" enable-background="new 0 0 595.3 841.9" xml:space="preserve">
+	 width="32px" height="32px" viewBox="0 0 595.3 841.9" enable-background="new 0 0 595.3 841.9" xml:space="preserve">
 <g id="Ebene_2_1_">
 	<circle fill="#52658A" cx="283.3" cy="434.4" r="348.9"/>
 </g>


### PR DESCRIPTION
In order to prevent this huge icons where ILIAS fails to properly set a size. (https://srag.freshdesk.com/helpdesk/tickets/16623)