### PR TITLE
solved problemms with invalid redirects in non-anonymous votings

### DIFF
--- a/classes/class.ilObjLiveVotingGUI.php
+++ b/classes/class.ilObjLiveVotingGUI.php
@@ -497,7 +497,7 @@ class ilObjLiveVotingGUI extends ilObjectPluginGUI {
 			 * @var ilCtrl $ilCtrl
 			 */
 			$ilCtrl->initBaseClass('ilUIPluginRouterGUI');
-			$ilCtrl->setTargetScript(xlvoConf::getFullApiURL());
+			$ilCtrl->setTargetScript(ltrim(xlvoConf::getFullApiURL(),'./'));
 			$ilCtrl->redirectByClass(array(
 				'ilUIPluginRouterGUI',
 				'xlvoVoter2GUI',


### PR DESCRIPTION
adapted target script format to ilUtil::redirect functionality

When trying to use the non anonymous mode of live votings plugin, alleged participants were redirected to an invalid address, where the ilias root-folder was skipped