### PR TITLE
Uncommented method to possibly fix a bug with number range inputs

### DIFF
--- a/classes/QuestionTypes/NumberRange/class.xlvoNumberRangeGUI.php
+++ b/classes/QuestionTypes/NumberRange/class.xlvoNumberRangeGUI.php
@@ -49,13 +49,11 @@ class xlvoNumberRangeGUI extends xlvoQuestionTypesGUI {
 	}
 
 
-	/* *
-	 *
-	 * /
+
 	protected function clear() {
 		$this->manager->unvoteAll();
 		$this->afterSubmit();
-	}*/
+	}
 
 	/**
 	 *


### PR DESCRIPTION
If you create a "Range Input"-Question, there is a clear button on the GUI which is activated after the user gave his first answer. If the user clicks on this button, he gets an error and will be redirected to the error page.

The error mesage was: `Call to undefined method xlvoNumberRangeGUI::clear()`

As I found in the class xlvoNumberRangeGUI, around line 53, the function `clear()` is commented out. If I uncomment this method, it seems to work.

I don't know LiveVoting well enough to know if this really is a bugfix. Just wanted to let you know about it with this PR.