### PR TITLE
Use ilException in xlvoVotingManager2

### DIFF
--- a/src/Voting/xlvoVotingManager2.php
+++ b/src/Voting/xlvoVotingManager2.php
@@ -3,6 +3,7 @@
 namespace LiveVoting\Voting;
 
 use ActiveRecordList;
+use ilException;
 use ilLiveVotingPlugin;
 use LiveVoting\Context\Param\ParamManager;
 use LiveVoting\Exceptions\xlvoPlayerException;


### PR DESCRIPTION
In order to refer to global classes in namespaced areas, either an explicit `use` must be declared or the reference must be prefixed with a backslash (`\GlobalClass`) when used. Code here seems to prefer `use` statements.

Even though, this will fix the "LiveVoting\Voting\ilException" not found error, the GUI will still not display any useful error message in case of a missing PIN.