### PR TITLE
Unbreak delete-an-option

### DIFF
--- a/src/QuestionTypes/SingleVote/xlvoSingleVoteSubFormGUI.php
+++ b/src/QuestionTypes/SingleVote/xlvoSingleVoteSubFormGUI.php
@@ -148,6 +148,7 @@ class xlvoSingleVoteSubFormGUI extends xlvoSubFormGUI {
 				$xlvoOption->delete();
 			}
 		}
+		$this->getXlvoVoting()->setVotingOptions($this->options);
 		$this->getXlvoVoting()->renegerateOptionSorting();
 	}
 }


### PR DESCRIPTION
Update options prior to storing them: Currently, it is not possible to delete an option in a SC/MC question through GUI because it is first deleted but later restored in renegerateOptionSorting().