### PR TITLE
Fixed issue with other plugins calling ilUtil::getImagePath

### DIFF
--- a/src/Context/Initialisation/Version/v53/xlvoStyleDefinition.php
+++ b/src/Context/Initialisation/Version/v53/xlvoStyleDefinition.php
@@ -37,6 +37,14 @@ class xlvoStyleDefinition {
 	public function getSkin() {
 		return $this->skin;
 	}
+	
+	/**
+	 * @return string
+	 */
+	public function getImageDirectory($style_id)
+	{
+		return '';
+	}
 }
 
 /**


### PR DESCRIPTION
We detected an issue with the `LiveVoting` plugin and other UI-Hook-plugins, if (for instance) `https://my.ilias.de/Customizing/global/plugins/Services/Repository/RepositoryObject/LiveVoting/pin.php?xlvo_pin=V5OA` is requested and these other plugins call `ilUtil::getImagePath` very late.

In this case, `$DIC["styleDefinition"]` in `ilUtil::getImagePath` is an instance of `\LiveVoting\Context\Initialisation\Version\v53\xlvoStyleDefinition`, which is missing the `getImageDirectory` method.

Error Message:
```
2019/09/06 15:02:49 [error] 1467#1467: *1188 FastCGI sent in stderr: "PHP message: Call to undefined method LiveVoting\Context\Initialisation\Version\v53\xlvoStyleDefinition::getImageDirectory()" while reading response header from upstream, client: 127.0.0.1, server: localhost-php7, request: "GET /databay/ilias/Customizing/global/plugins/Services/Repository/RepositoryObject/LiveVoting/ilias.php?xlvo_pin=V5OA&cmd=startVoterPlayer&cmdClass=xlvovoter2gui&cmdNode=12t:14s&baseClass=ilUIPluginRouterGUI HTTP/1.1", upstream: "fastcgi://unix:/run/php/php7.0-fpm.sock:", host: "localhost-php7"
```
