### PR TITLE
fix rbacreview problem

### DIFF
--- a/src/Context/xlvoRbacReview.php
+++ b/src/Context/xlvoRbacReview.php
@@ -57,4 +57,8 @@ class xlvoRbacReview
     {
         return [];
     }
+
+    public function isAssignedToAtLeastOneGivenRole(){
+        return false;
+    }
 }


### PR DESCRIPTION
A second UI-Component plugin on our installation uses the function isAssignedToAtLeastOneGivenRole() on the xlvoRbacReview mock. Since this mock is set as the global RbacReview, there is always an error when opening the pin.php. The problem is solved by adding that function to the mock, like in this commit.